### PR TITLE
Allows multiple SB's to be timed and ignores scripting lag.

### DIFF
--- a/scripts/spamCity.txt
+++ b/scripts/spamCity.txt
@@ -1,3 +1,4 @@
+lagCorrection = 1
 cityToSpam = "562,688"
 cavAttack = "c:5k,s:5k"
 sbAttack = "s:125k"
@@ -14,8 +15,10 @@ execute "scout {cityToSpam} any {scouts}"
 label die
 getspamhero
 execute "attack {cityToSpam} {spammers} {cavAttack}"
-execute "sleep {delay}"
+time=date($result.reachTime-(lagCorrection*1000)).toString().split(" ")[3]
 getspamhero
-execute "scout {cityToSpam} any {scouts}"
-execute "attack {cityToSpam} {spammers} {sbAttack}"
+execute "scout {cityToSpam} any {scouts} @:{time}"
+label sbAgain
+execute "attack {cityToSpam} {spammers} {sbAttack} f:0 @:{time}"
+if m_city.AnyIdleHero("{spammers}") repeat
 goto die


### PR DESCRIPTION
Use of $result.time makes it possible to immediate add sb's to the first wave also allows multiple sb's at the same second and not only the first sb that is send.

Plus ignores scripting lag / 1 sec per line.
